### PR TITLE
Add React Routing, update readme steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # Flask and `create-react-app`
 
 ## Requirements
+
 1. `npm install`
-2. `pip install -r requirements.txt`
+2. `npm install react-router-dom`
+3. `pip install -r requirements.txt`
 
 ## Run Application
+
 1. Run command in terminal (in your project directory): `npm run build`. This will update anything related to your `App.js` file (so `public/index.html`, any CSS you're pulling in, etc).
 2. Run command in terminal (in your project directory): `python3 app.py`
 3. Preview web page in browser 'localhost:8080/' (or whichever port you're using)
 
 ## Deploy to Heroku
+
 1. Create a Heroku app: `heroku create --buildpack heroku/python`
 2. Add nodejs buildpack: `heroku buildpacks:add --index 1 heroku/nodejs`
 3. Push to Heroku: `git push heroku main`

--- a/app.py
+++ b/app.py
@@ -5,14 +5,15 @@ import json
 
 
 app = flask.Flask(__name__, static_folder='./build/static')
-# This tells our Flask app to look at the results of `npm build` instead of the 
+# This tells our Flask app to look at the results of `npm build` instead of the
 # actual files in /templates when we're looking for the index page file. This allows
 # us to load React code into a webpage. Look up create-react-app for more reading on
 # why this is necessary.
 bp = flask.Blueprint("bp", __name__, template_folder="./build")
 
+
 @bp.route('/index')
-@login_required
+# @login_required
 def index():
     # TODO: insert the data fetched by your app main page here as a JSON
     DATA = {"your": "data here"}
@@ -22,34 +23,23 @@ def index():
         data=data,
     )
 
+
 app.register_blueprint(bp)
-
-@app.route('/signup')
-def signup():
-	...
-
-@app.route('/signup', methods=["POST"])
-def signup_post():
-	...
-
-@app.route('/login')
-def login():
-    ...
-
-@app.route('/login', methods=["POST"])
-def login_post():
-	...
-
-@app.route('/save', methods=["POST"])
-def save():
-    ...
 
 
 @app.route('/')
 def main():
-	...
+    return ""
 
 
+@app.route('/login/')
+def login():
+    return ""
+
+
+@app.route('/register/')
+def register():
+    return ""
 
 
 app.run(

--- a/app.py
+++ b/app.py
@@ -35,7 +35,7 @@ def index():
     data = json.dumps(DATA)
     return flask.render_template("index.html", data=data,)
 
-  
+
 app.register_blueprint(bp)
 
 
@@ -44,7 +44,7 @@ def login():
     """Login"""
     return flask.render_template("login.html")
 
-  
+
 @app.route("/login", methods=["POST"])
 def login_post():
     """Login"""
@@ -101,7 +101,7 @@ def signup_post():
     # add the new user to the database
     db.session.add(new_user)
     db.session.commit()
-    
+
     return flask.redirect(flask.url_for("login"))
 
 
@@ -117,6 +117,11 @@ def logout():
 def home():
     """Home"""
     return flask.render_template("main.html")
+
+
+@app.errorhandler(404)
+def not_found(e):
+    return flask.render_template("index.html")
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import os
 import json
 
 
-app = flask.Flask(__name__, static_folder='./build/static')
+app = flask.Flask(__name__, static_folder="./build/static")
 # This tells our Flask app to look at the results of `npm build` instead of the
 # actual files in /templates when we're looking for the index page file. This allows
 # us to load React code into a webpage. Look up create-react-app for more reading on
@@ -12,37 +12,36 @@ app = flask.Flask(__name__, static_folder='./build/static')
 bp = flask.Blueprint("bp", __name__, template_folder="./build")
 
 
-@bp.route('/index')
+@bp.route("/index")
 # @login_required
 def index():
     # TODO: insert the data fetched by your app main page here as a JSON
     DATA = {"your": "data here"}
     data = json.dumps(DATA)
-    return flask.render_template(
-        "index.html",
-        data=data,
-    )
+    return flask.render_template("index.html", data=data,)
 
 
 app.register_blueprint(bp)
 
 
-@app.route('/')
+@app.route("/")
 def main():
     return ""
 
 
-@app.route('/login/')
+@app.route("/login/")
 def login():
     return ""
 
 
-@app.route('/register/')
+@app.route("/register/")
 def register():
     return ""
 
 
-app.run(
-    host=os.getenv('IP', '0.0.0.0'),
-    port=int(os.getenv('PORT', 8081)),
-)
+@app.errorhandler(404)
+def not_found(e):
+    return flask.render_template("index.html")
+
+
+app.run(host=os.getenv("IP", "0.0.0.0"), port=int(os.getenv("PORT", 8080)), debug=True)

--- a/public/index.html
+++ b/public/index.html
@@ -27,19 +27,13 @@
 </head>
 
 <body>
+  {% if current_user.is_authenticated %}
   <script id="data" type="application/json">{{data|safe}}</script>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
-  <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
+  {%else%}
+  <div>ERROR</div>
+  {%endif%}
 </body>
 
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -14,8 +14,6 @@ function App() {
       <div>
         <Nav />
         <Routes>
-          {/* <Route path="/login" element={<Login />} />
-          <Route path="/register" element={<Register />} /> */}
           <Route path="/profile" element={<Profile />} />
           <Route path="/pokemon" element={<Pokemon />} />
           <Route path="/top" element={<Top />} />

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,29 @@
-import logo from './logo.svg';
+import React from 'react';
 import './App.css';
-import { useState, useRef } from 'react';
-
+import Nav from './Nav';
+import Profile from './Profile';
+import Pokemon from './Pokemon';
+import Search from './Search';
+import Top from './Top';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
 function App() {
-  // fetches JSON data passed in by flask.render_template and loaded
-  // in public/index.html in the script with id "data"
-  const args = JSON.parse(document.getElementById("data").text);
-
-  // TODO: Implement your main page as a React component.
+  //const args = JSON.parse(document.getElementById('data').text);
+  return (
+    <Router>
+      <div>
+        <Nav />
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} />
+          <Route path="/profile" element={<Profile />} />
+          <Route path="/pokemon" element={<Pokemon />} />
+          <Route path="/top" element={<Top />} />
+          <Route path="/search" element={<Search />} />
+        </Routes>
+      </div>
+    </Router>
+  );
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -14,8 +14,8 @@ function App() {
       <div>
         <Nav />
         <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/register" element={<Register />} />
+          {/* <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} /> */}
           <Route path="/profile" element={<Profile />} />
           <Route path="/pokemon" element={<Pokemon />} />
           <Route path="/top" element={<Top />} />

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import './app.css';
+import { Link } from 'react-router-dom';
+
+function Nav() {
+  return (
+    <nav>
+      <div>PokeRevs</div>
+      <ul>
+        <li>
+          <Link to="/profile">Profile</Link>
+        </li>
+        <li>
+          <Link to="/search">Search</Link>
+        </li>
+        <li>
+          <Link to="/top">Top</Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}
+
+export default Nav;

--- a/src/Pokemon.js
+++ b/src/Pokemon.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import './app.css';
+
+function Pokemon() {
+  return (
+    <div>
+      <h3>Specific Pokemon Page</h3>
+    </div>
+  );
+}
+
+export default Pokemon;

--- a/src/Profile.js
+++ b/src/Profile.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import './app.css';
+
+function Profile() {
+    return (
+        <div>
+            <h3>Welcome!</h3>
+        </div>
+    );
+}
+
+export default Profile;

--- a/src/Search.js
+++ b/src/Search.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import './app.css';
+
+function Search() {
+  return (
+    <div>
+      <h3>Search Page</h3>
+    </div>
+  );
+}
+
+export default Search;

--- a/src/Top.js
+++ b/src/Top.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import './app.css';
+
+function Top() {
+  return (
+    <div>
+      <h3>Top Pokemon</h3>
+      <ol>
+        <li>Charizard</li>
+        <li>Squirtle</li>
+        <li>Torchick</li>
+        <li>Incineroar</li>
+      </ol>
+    </div>
+  );
+}
+
+export default Top;


### PR DESCRIPTION
I added the skeleton for the react routing pages:
Login and Register pages are not routed--I think they might be better done in flask jinja templates? First have the users log in or register, and when they log in, we can serve the React pages to make things simpler
The way it's set up is this--go to "/" endpoint: nothing shows up (this is a flask endpoint). Go to "/index"-- React components show up (see: app.js).
Let me know if any changes need to be made.