### PR TITLE
display reviews as list, also fix psycopg2 req. and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 1. `npm install`
 2. `npm install react-router-dom`
-3. `pip install -r requirements.txt`
+3. `npm install prop-types`
+4. `pip install -r requirements.txt`
 
 ## Run Application
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask
 python-dotenv
 requests
 Werkzeug
-psycopg2
+psycopg2-binary
 flask_login
 flask_sqlalchemy
 uuid

--- a/src/Profile.js
+++ b/src/Profile.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import './App.css';
 import propTypes from 'prop-types';
 import { getReviews, updateProfile } from './Backend';
+import { Link } from 'react-router-dom';
 
 function Profile(props) {
   const [reviews, updateReviews] = useState('');
@@ -61,8 +62,32 @@ Profile.propTypes = {
 
 function ReviewList(props) {
   let promise = getReviews(props.username);
-  promise.then((data) => props.update(JSON.stringify(data)));
-  return <div>{props.reviews}</div>;
+  promise.then((data) => {
+    props.update(JSON.stringify(data));
+  });
+  if (!props.reviews) {
+    return <div></div>;
+  }
+  const data = JSON.parse(props.reviews);
+  return (
+    <div>
+      {data['reviews'].map((review) => {
+        return (
+          <div>
+            <span>
+              <h3>
+                <Link to={'/pokemon/' + review.pokedex_id}>{review.title}</Link>
+              </h3>
+              <h5>{review.rating} out of 10</h5>
+            </span>
+            <span>Pokedex_id: {review.pokedex_id}</span>
+            <span> by {review.username}</span>
+            <div>{review.body}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 ReviewList.propTypes = {


### PR DESCRIPTION
I turned the json data of the profile page's reviews into something a bit more presentable. The title of each review links to the pokemon being reviewed (/pokemon/{pokedex_id}). Also readme had an extra dependency (maybe more in the future), and psycopg2-binary is the correct pip package.